### PR TITLE
Add a method to execute any tagged command and listen to the result

### DIFF
--- a/core/src/main/java/com/lafaspot/imapnio/client/IMAPSession.java
+++ b/core/src/main/java/com/lafaspot/imapnio/client/IMAPSession.java
@@ -444,6 +444,24 @@ public class IMAPSession {
     }
 
     /**
+     * Execute a IMAP raw command handling tag and listener.
+     *
+     * @param tag IMAP tag to be used
+     * @param rawText the raw text to be sent to the remote IMAP server
+     * @param listener the session listener
+     * @return the future object
+     * @throws IMAPSessionException when channel is invalid
+     */
+    public IMAPChannelFuture executeTaggedRawTextCommand(final String tag, final String rawText,
+            final IMAPCommandListener listener) throws IMAPSessionException {
+        if (state.get() != IMAPSessionState.CONNECTED) {
+            throw new IMAPSessionException("Sending raw command in invalid state " + state.get());
+        }
+
+        return new IMAPChannelFuture(executeCommand(new ImapCommand(tag, rawText, null, new String[] {}), listener));
+    }
+
+    /**
      * Execute a IMAP NOOP command.
      *
      * @param tag IMAP tag to be used


### PR DESCRIPTION
Hi again,

We use this method to implement quickly FETCH in our gatling-imap project.
See: https://github.com/linagora/gatling-imap/blob/master/src/main/scala-2.11/com/linagora/gatling/imap/protocol/command/FetchHandler.scala#L73

I think it might me interesting to the imapnio project.

Regards,
Raphaël Ouazana.