### PR TITLE
register listener before executing command

### DIFF
--- a/core/src/main/java/com/lafaspot/imapnio/client/IMAPSession.java
+++ b/core/src/main/java/com/lafaspot/imapnio/client/IMAPSession.java
@@ -588,13 +588,12 @@ public class IMAPSession {
 
         final Channel channel = this.channelRef.get();
         if (null != channel) {
-            final ChannelFuture lastWriteFuture = channel.writeAndFlush(line + "\r\n");
             if (null != listener && !method.getTag().isEmpty()) {
                 final String tag = method.getTag();
                 currentTagRef.set(tag);
                 commandListeners.put(tag, listener);
             }
-            return lastWriteFuture;
+            return channel.writeAndFlush(line + "\r\n");
         }
         throw new IMAPSessionException("Invalid channel closed");
     }


### PR DESCRIPTION
This PR register the listener before executing the command.
We encountered some problems where a command (LIST) was too fast and the listener were never called.