### PR TITLE
Add more support in IMAP NIO commands.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
 language: java
 jdk:
 - oraclejdk8
+dist: trusty
 before_install:
 install:
 - mvn clean install -Dgpg.skip=true

--- a/README.md
+++ b/README.md
@@ -68,16 +68,15 @@ The following code examples demonstrate basic functionality relate to connecting
   // Create a new session via the ImapAsyncClient instance created above and connect to that server.  For the illustration purpose, 
   // "imaps://imap.server.com:993" is used
   final URI serverUri = new URI("imaps://imap.server.com:993");
-  final Properties properties = new Properties();
-  properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-  properties.put("mail.imap.timeout", String.valueOf("60000"));
-  properties.put("mail.imap.inactivity", "3");
+  final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+  config.setConnectionTimeoutMillis(5000);
+  config.setReadTimeoutMillis(6000);
   final List<String> sniNames = null;
 
   final LogManager logManager = new LogManager(Level.DEBUG, LogPage.DEFAULT_SIZE);
   logManager.setLegacy(true);
   final InetSocketAddress localAddress = null;
-  final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+  final Future<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
   
   //this version is a future-based nio client.  Check whether future is done by following code.
   if (future.isDone()) {
@@ -90,7 +89,7 @@ Following codes uses a Capability command as an example.
 
 ```java
   // Executes the capability command
-  final ImapFuture<ImapAsyncResponse> capaCmdFuture = session.execute(new CapaCommand());
+  final Future<ImapAsyncResponse> capaCmdFuture = session.execute(new CapaCommand());
 
 ```
 

--- a/core/src/main/java/com/lafaspot/imapnio/async/client/ImapAsyncSession.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/client/ImapAsyncSession.java
@@ -10,14 +10,26 @@ import com.lafaspot.imapnio.async.request.ImapRequest;
 import com.lafaspot.imapnio.async.response.ImapAsyncResponse;
 
 /**
- * A class that defines the behavior of Asynchronous imap session.
+ * A class that defines the behavior of Asynchronous IMAP session.
  */
 public interface ImapAsyncSession {
 
     /**
-     * Sends a imap command to the server.
+     * Starts the compression, assuming caller verified the support of compression capability in server.
      *
-     * @param <T> the data type for retruning in getNextCommandLineAfterContinuation call
+     * @param <T> the data type for returning in getNextCommandLineAfterContinuation call
+     *
+     * @return the future object for this command
+     * @throws ImapAsyncClientException on failure
+     * @throws IOException when encountering IO exception
+     * @throws SearchException when a search expression cannot be handled, conformed to RFC3501 standard
+     */
+    <T> ImapFuture<ImapAsyncResponse> startCompression() throws ImapAsyncClientException, SearchException, IOException;
+
+    /**
+     * Sends a IMAP command to the server.
+     *
+     * @param <T> the data type for returning in getNextCommandLineAfterContinuation call
      *
      * @param command the command request.
      * @return the future object for this command
@@ -28,7 +40,7 @@ public interface ImapAsyncSession {
     <T> ImapFuture<ImapAsyncResponse> execute(ImapRequest<T> command) throws ImapAsyncClientException, IOException, SearchException;
 
     /**
-     * Terminates the currenct running command.
+     * Terminates the current running command.
      *
      * @param command the command request.
      * @return the future object for this command

--- a/core/src/main/java/com/lafaspot/imapnio/async/client/ImapAsyncSessionConfig.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/client/ImapAsyncSessionConfig.java
@@ -1,0 +1,57 @@
+package com.lafaspot.imapnio.async.client;
+
+/**
+ * Class for IMAP Client connection and channel settings.
+ */
+public final class ImapAsyncSessionConfig {
+
+    /** Default connection timeout value in milliseconds. */
+    public static final int DEFAULT_CONNECTION_TIMEOUT_MILLIS = 10000;
+
+    /** Default IMAP command response read from server timeout value in milliseconds. */
+    public static final int DEFAULT_READ_TIMEOUT_MILLIS = 10000;
+
+    /**
+     * Maximum time in milliseconds for opening a connection, this maps to CONNECT_TIMEOUT_MILLIS in @{code ChannelOption}, it will be used when
+     * establishing a connection.
+     */
+    private int connectionTimeoutMillis = DEFAULT_CONNECTION_TIMEOUT_MILLIS;
+
+    /**
+     * Maximum time in milliseconds for read timeout, this maps to the readIdleTime in @{code IdleStateHandler}.
+     */
+    private int readTimeoutMillis = DEFAULT_READ_TIMEOUT_MILLIS;
+
+    /**
+     * @return Maximum time for opening a connection
+     */
+    public int getConnectionTimeoutMillis() {
+        return connectionTimeoutMillis;
+    }
+
+    /**
+     * Sets the maximum time for opening a connection in milliseconds.
+     * 
+     * @param connectionTimeoutMillis time in milliseconds
+     */
+    public void setConnectionTimeoutMillis(final int connectionTimeoutMillis) {
+        this.connectionTimeoutMillis = connectionTimeoutMillis;
+    }
+
+    /**
+     * @return Maximum time for read timeout
+     */
+    public int getReadTimeoutMillis() {
+        return readTimeoutMillis;
+    }
+
+    /**
+     * Sets the maximum time for read timeout, this means the time waiting for server to respond.
+     * 
+     * @param readTimeoutMillis time in milliseconds
+     */
+    public void setReadTimeoutMillis(final int readTimeoutMillis) {
+        this.readTimeoutMillis = readTimeoutMillis;
+    }
+
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/data/IdResult.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/data/IdResult.java
@@ -1,0 +1,44 @@
+package com.lafaspot.imapnio.async.data;
+
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This class provides the functionality to allow callers to obtain Id command result given by imap server.
+ */
+public final class IdResult {
+
+    /** IdResult list. */
+    private final Map<String, String> params;
+
+    /**
+     * Initializes the @{code IdResult} class.
+     *
+     * @param map map of capability name with its values if existing
+     */
+    public IdResult(@Nonnull final Map<String, String> map) {
+        this.params = map;
+    }
+
+    /**
+     * Returns true if the keyName given is present in the id list; false otherwise.
+     *
+     * @param keyName the capability name to find
+     * @return true if the result has the key; false otherwise
+     */
+    public boolean hasKey(@Nullable final String keyName) {
+        return params.containsKey(keyName);
+    }
+
+    /**
+     * Returns the value based on the given key name.
+     *
+     * @param keyName the capability name to find
+     * @return the value
+     */
+    public String getValue(@Nullable final String keyName) {
+        return params.get(keyName);
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/exception/ImapAsyncClientException.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/exception/ImapAsyncClientException.java
@@ -53,6 +53,9 @@ public class ImapAsyncClientException extends Exception {
         /** Timeout from server. */
         CHANNEL_TIMEOUT("Timeout from server after command is sent."),
 
+        /** Given class type to parse to is unknown. */
+        UNKNOWN_PARSE_RESULT_TYPE("Given class type to parse to is unknown."),
+
         /** Invalid input. */
         INVALID_INPUT("Input is invalid.");
 

--- a/core/src/main/java/com/lafaspot/imapnio/async/internal/CompressCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/internal/CompressCommand.java
@@ -1,0 +1,24 @@
+package com.lafaspot.imapnio.async.internal;
+
+import com.lafaspot.imapnio.async.request.AbstractNoArgsCommand;
+
+/**
+ * This class defines imap Compress request from client.
+ * 
+ * @see "RFC 4978"
+ */
+final class CompressCommand extends AbstractNoArgsCommand {
+
+    /** Command name. */
+    private static final String COMPRESS_DEFLATE = "COMPRESS DEFLATE";
+
+    /**
+     * Initializes the @{code COMPRESS_DEFLATECommand}. Constructor is only visible to this package so it can only be called by @{code
+     * ImapAsyncSessionImpl}.
+     * 
+     * @see "RFC 4978"
+     */
+    CompressCommand() {
+        super(COMPRESS_DEFLATE);
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/internal/ImapAsyncSessionImpl.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/internal/ImapAsyncSessionImpl.java
@@ -11,6 +11,7 @@ import javax.mail.search.SearchException;
 
 import org.slf4j.Logger;
 
+import com.lafaspot.imapnio.async.client.ImapAsyncClient;
 import com.lafaspot.imapnio.async.client.ImapAsyncSession;
 import com.lafaspot.imapnio.async.client.ImapFuture;
 import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
@@ -28,6 +29,9 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.compression.JdkZlibDecoder;
+import io.netty.handler.codec.compression.JdkZlibEncoder;
+import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.timeout.IdleStateEvent;
 
 /**
@@ -44,11 +48,17 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
     /** Debug log record for this class, due to channel or client input error, first {} is sessionId, 2nd {} is for message. */
     private static final String INTERNAL_LOG_REC = "[{}] I:{}";
 
-    /** Debug message for donoting client error. */
+    /** Debug message for denoting client error. */
     private static final String CLIENT_ERROR = " Client Error.";
 
     /** Tag prefix. */
     private static final char A = 'a';
+
+    /** Deflater handler name for enabling server compress. */
+    private static final String ZLIB_DECODER = "DEFLATER";
+
+    /** Inflater handler name for enabling server compress. */
+    private static final String ZLIB_ENCODER = "INFLATER";
 
     /** The Netty channel object. */
     private AtomicReference<Channel> channelRef = new AtomicReference<Channel>();
@@ -64,6 +74,9 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
 
     /** Sequence number for tag. */
     private AtomicLong tagSequence;
+
+    /** Flag to indicate compression is sent and pending to server. */
+    private boolean isCompressionRequestPending;
 
     /**
      * This class handles and manages response from server and determines whether the job for this request is done. When the request is done, it sets
@@ -135,6 +148,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         this.sessionId = sessionId;
         this.requestsQueue = new ConcurrentLinkedQueue<ImapCommandEntry>();
         this.tagSequence = new AtomicLong(0);
+        this.isCompressionRequestPending = false;
         pipeline.addLast(ImapClientCommandRespHandler.HANDLER_NAME, new ImapClientCommandRespHandler(this));
     }
 
@@ -164,6 +178,14 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         sendRequest(sb.toString());
 
         return cmdFuture;
+    }
+
+    @Override
+    public <T> ImapFuture<ImapAsyncResponse> startCompression() throws ImapAsyncClientException, SearchException, IOException {
+        final ImapFuture<ImapAsyncResponse> future = execute(new CompressCommand());
+        // set it to true only after submitted without failure
+        isCompressionRequestPending = true;
+        return future;
     }
 
     /**
@@ -201,6 +223,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
 
     /**
      * Listens to write to server complete future.
+     * 
      * @param future ChannelFuture instance to check whether the future has completed successfully
      */
     @Override
@@ -269,6 +292,7 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
         if (entry == null) {
             return;
         }
+        isCompressionRequestPending = false; // always shut it off
         entry.getFuture().done(cause);
     }
 
@@ -317,6 +341,23 @@ public class ImapAsyncSessionImpl implements ImapAsyncSession, ImapCommandChanne
             return;
 
         } else if (serverResponse.isTagged()) {
+            if (isCompressionRequestPending) {
+                isCompressionRequestPending = false; // no longer pending after server responds
+                if (serverResponse.isOK()) {
+                    final Channel ch = channelRef.get();
+                    final ChannelPipeline pipeline = ch.pipeline();
+                    final JdkZlibDecoder decoder = new JdkZlibDecoder(ZlibWrapper.NONE);
+                    final JdkZlibEncoder encoder = new JdkZlibEncoder(ZlibWrapper.NONE, 5);
+                    if (pipeline.get(ImapAsyncClient.SSL_HANDLER) == null) {
+                        // no SSL handler, deflater/enflater has to be first
+                        pipeline.addFirst(ZLIB_DECODER, decoder);
+                        pipeline.addFirst(ZLIB_ENCODER, encoder);
+                    } else {
+                        pipeline.addAfter(ImapAsyncClient.SSL_HANDLER, ZLIB_DECODER, decoder);
+                        pipeline.addAfter(ImapAsyncClient.SSL_HANDLER, ZLIB_ENCODER, encoder);
+                    }
+                }
+            }
             // see rfc3501, page 63 for details, since we always give a tagged command, response completion should be the first tagged response
             final ImapAsyncResponse doneResponse = new ImapAsyncResponse(responses);
             removeFirstEntry();

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/AbstractMessageActionCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/AbstractMessageActionCommand.java
@@ -22,7 +22,7 @@ abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
     /** A collection of messages specified based on RFC3501 syntax. */
     private String msgset;
 
-    /** The destionation folder for the email to copy to. */
+    /** The destination folder for the email to copy to. */
     private String targetFolder;
 
     /**
@@ -58,10 +58,10 @@ abstract class AbstractMessageActionCommand extends ImapRequestAdapter {
      *
      * @param op the command
      * @param isUid true if it is a uid sequence
-     * @param msgset the messages set
+     * @param msgset the messages set string
      * @param targetFolder the targetFolder to be stored
      */
-    private AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final String msgset,
+    protected AbstractMessageActionCommand(@Nonnull final String op, final boolean isUid, @Nonnull final String msgset,
             @Nonnull final String targetFolder) {
         this.op = op;
         this.isUid = isUid;

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/AbstractNoArgsCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/AbstractNoArgsCommand.java
@@ -5,17 +5,17 @@ import javax.annotation.Nonnull;
 /**
  * This class defines an Imap command that has no arguments sent from client.
  */
-abstract class AbstractNoArgsCommand extends ImapRequestAdapter {
+public abstract class AbstractNoArgsCommand extends ImapRequestAdapter {
 
     /** The Command. */
     private String op;
 
     /**
-     * Initalizes an IMAP command that has no arguments.
+     * Initializes an IMAP command that has no arguments.
      *
      * @param op imap command string. For example, "NOOP"
      */
-    AbstractNoArgsCommand(@Nonnull final String op) {
+    protected AbstractNoArgsCommand(@Nonnull final String op) {
         super();
         this.op = op;
     }

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/AppendCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/AppendCommand.java
@@ -55,10 +55,10 @@ public class AppendCommand implements ImapRequest<ByteBuf> {
 
     @Override
     public void cleanup() {
-        this.folderName =  null;
+        this.folderName = null;
         this.flags = null;
         this.date = null;
-        this.data =  null;
+        this.data = null;
     }
 
     @Override

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/CopyMessageCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/CopyMessageCommand.java
@@ -15,23 +15,21 @@ public class CopyMessageCommand extends AbstractMessageActionCommand {
     /**
      * Initializes a @{code CopyMessageCommand} with the message sequence syntax.
      *
-     * @param isUid true if it is a uid sequence
      * @param msgsets the set of message set
      * @param targetFolder the targetFolder to be stored
      */
-    public CopyMessageCommand(final boolean isUid, @Nonnull final MessageSet[] msgsets, @Nonnull final String targetFolder) {
-        super(COPY, isUid, msgsets, targetFolder);
+    public CopyMessageCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final String targetFolder) {
+        super(COPY, false, msgsets, targetFolder);
     }
 
     /**
      * Initializes a @{code CopyMessageCommand} with the start and end message sequence.
      *
-     * @param isUid true if it is a uid sequence
      * @param start the starting message sequence
      * @param end the ending message sequence
      * @param targetFolder the targetFolder to be stored
      */
-    public CopyMessageCommand(final boolean isUid, final int start, final int end, @Nonnull final String targetFolder) {
-        super(COPY, isUid, start, end, targetFolder);
+    public CopyMessageCommand(final int start, final int end, @Nonnull final String targetFolder) {
+        super(COPY, false, start, end, targetFolder);
     }
 }

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/FetchCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/FetchCommand.java
@@ -9,14 +9,8 @@ import com.sun.mail.imap.protocol.MessageSet;
  */
 public class FetchCommand extends ImapRequestAdapter {
 
-    /** UID FETCH and space. */
-    private static final String UID_FETCH_SPACE = "UID FETCH ";
-
     /** FETCH and space. */
     private static final String FETCH_SPACE = "FETCH ";
-
-    /** Flag to indicate whether the message numbers are uid. */
-    private boolean isUid;
 
     /** Message Id, either message sequence or UID. */
     private String msgIds;
@@ -27,35 +21,31 @@ public class FetchCommand extends ImapRequestAdapter {
     /**
      * Initializes a @{code FetchCommand} with the message sequence syntax.
      *
-     * @param isUid flag to indicate whether the message numbers are uid
      * @param msgsets the set of message set
      * @param what the data items or macro
      */
-    public FetchCommand(final boolean isUid, @Nonnull final MessageSet[] msgsets, @Nonnull final String what) {
-        this(isUid, MessageSet.toString(msgsets), what);
+    public FetchCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final String what) {
+        this(MessageSet.toString(msgsets), what);
     }
 
     /**
      * Initializes a @{code FetchCommand} with the start and end message sequence.
      *
-     * @param isUid flag to indicate whether the message numbers are uid
      * @param msgStart the starting message sequence
      * @param msgEnd the ending message sequence
      * @param what the data items or macro
      */
-    public FetchCommand(final boolean isUid, final int msgStart, final int msgEnd, @Nonnull final String what) {
-        this(isUid, new StringBuilder(String.valueOf(msgStart)).append(ImapClientConstants.COLON).append(String.valueOf(msgEnd)).toString(), what);
+    public FetchCommand(final int msgStart, final int msgEnd, @Nonnull final String what) {
+        this(new StringBuilder(String.valueOf(msgStart)).append(ImapClientConstants.COLON).append(String.valueOf(msgEnd)).toString(), what);
     }
 
     /**
      * Initializes a @{code FetchCommand} with the message sequence syntax.
      *
-     * @param isUid flag to indicate whether the message numbers are uid
      * @param msgIds the message sequence or UID string. For ex:2:4
      * @param what the data items or macro
      */
-    private FetchCommand(final boolean isUid, @Nonnull final String msgIds, @Nonnull final String what) {
-        this.isUid = isUid;
+    private FetchCommand(@Nonnull final String msgIds, @Nonnull final String what) {
         this.msgIds = msgIds;
         this.dataItems = what;
     }
@@ -68,9 +58,9 @@ public class FetchCommand extends ImapRequestAdapter {
 
     @Override
     public String getCommandLine() {
-        final StringBuilder sb = new StringBuilder(dataItems.length() + ImapClientConstants.PAD_LEN).append(isUid ? UID_FETCH_SPACE : FETCH_SPACE)
-                .append(msgIds).append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN).append(dataItems)
-                .append(ImapClientConstants.R_PAREN).append(ImapClientConstants.CRLF);
+        final StringBuilder sb = new StringBuilder(dataItems.length() + ImapClientConstants.PAD_LEN).append(FETCH_SPACE).append(msgIds)
+                .append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN).append(dataItems).append(ImapClientConstants.R_PAREN)
+                .append(ImapClientConstants.CRLF);
 
         return sb.toString();
     }

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/MoveMessageCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/MoveMessageCommand.java
@@ -15,23 +15,21 @@ public class MoveMessageCommand extends AbstractMessageActionCommand {
     /**
      * Initializes a @{code MoveCommand} with the message sequence syntax.
      *
-     * @param isUid true if it is a uid sequence
      * @param msgsets the set of message set
      * @param targetFolder the targetFolder to be stored
      */
-    public MoveMessageCommand(final boolean isUid, @Nonnull final MessageSet[] msgsets, @Nonnull final String targetFolder) {
-        super(MOVE, isUid, msgsets, targetFolder);
+    public MoveMessageCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final String targetFolder) {
+        super(MOVE, false, msgsets, targetFolder);
     }
 
     /**
      * Initializes a @{code MoveCommand} with the start and end message sequence.
      *
-     * @param isUid true if it is a uid sequence
      * @param start the starting message sequence
      * @param end the ending message sequence
      * @param targetFolder the targetFolder to be stored
      */
-    public MoveMessageCommand(final boolean isUid, final int start, final int end, @Nonnull final String targetFolder) {
-        super(MOVE, isUid, start, end, targetFolder);
+    public MoveMessageCommand(final int start, final int end, @Nonnull final String targetFolder) {
+        super(MOVE, false, start, end, targetFolder);
     }
 }

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/StoreFlagsCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/StoreFlagsCommand.java
@@ -10,62 +10,52 @@ import com.sun.mail.imap.protocol.MessageSet;
  */
 public class StoreFlagsCommand extends ImapRequestAdapter {
 
-    /** UID STORE and space. */
-    private static final String UID_STORE_SPACE = "UID STORE ";
-
     /** Literal for STORE. */
     private static final String STORE_SP = "STORE ";
 
     /** Literal for FLAGS. */
     private static final String FLAGS_SP = "FLAGS ";
 
-    /** True if the message number represents UID; false if it represents Message Sequences. */
-    private boolean isUid;
-
     /** A collection of messages id specified based on RFC3501 syntax. */
     private String msgIds;
 
-    /** Messagesflags. */
+    /** Messages flags. */
     private Flags flags;
 
-    /** Flag to inidicate whether to add or remove existing. */
+    /** Flag to indicate whether to add or remove existing. */
     private final boolean isSet;
 
     /**
      * Initializes a @{code StoreFlagsCommand} with the MessageSet array.
      *
-     * @param isUid either uid or message sequence
      * @param msgsets the set of message set
      * @param flags the flags to be stored
      * @param set true if the specified flags are to be set, false to clear them
      */
-    public StoreFlagsCommand(final boolean isUid, @Nonnull final MessageSet[] msgsets, @Nonnull final Flags flags, final boolean set) {
-        this(isUid, MessageSet.toString(msgsets), flags, set);
+    public StoreFlagsCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final Flags flags, final boolean set) {
+        this(MessageSet.toString(msgsets), flags, set);
     }
 
     /**
      * Initializes a @{code StoreFlagsCommand} with the start and end message sequence.
      *
-     * @param isUid either uid or message sequence
      * @param start the starting message sequence
      * @param end the ending message sequence
      * @param flags the flags to be stored
      * @param set true if the specified flags are to be set, false to clear them
      */
-    public StoreFlagsCommand(final boolean isUid, final int start, final int end, @Nonnull final Flags flags, final boolean set) {
-        this(isUid, new StringBuilder(String.valueOf(start)).append(ImapClientConstants.COLON).append(String.valueOf(end)).toString(), flags, set);
+    public StoreFlagsCommand(final int start, final int end, @Nonnull final Flags flags, final boolean set) {
+        this(new StringBuilder(String.valueOf(start)).append(ImapClientConstants.COLON).append(String.valueOf(end)).toString(), flags, set);
     }
 
     /**
      * Initializes a @{code StoreFlagsCommand} with the msg string directly.
      *
-     * @param isUid either uid or message sequence
      * @param msgset the messages set
      * @param flags the flags to be stored
      * @param set true if the specified flags are to be set, false to clear them
      */
-    private StoreFlagsCommand(@Nonnull final boolean isUid, @Nonnull final String msgset, @Nonnull final Flags flags, final boolean set) {
-        this.isUid = isUid;
+    private StoreFlagsCommand(@Nonnull final String msgset, @Nonnull final Flags flags, final boolean set) {
         this.msgIds = msgset;
         this.flags = flags;
         this.isSet = set;
@@ -81,7 +71,7 @@ public class StoreFlagsCommand extends ImapRequestAdapter {
     public String getCommandLine() {
         // Ex:STORE 2:4 +FLAGS (\Deleted)
         final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
-        final StringBuilder sb = new StringBuilder(isUid ? UID_STORE_SPACE : STORE_SP).append(msgIds).append(ImapClientConstants.SPACE);
+        final StringBuilder sb = new StringBuilder(STORE_SP).append(msgIds).append(ImapClientConstants.SPACE);
 
         sb.append(isSet ? ImapClientConstants.PLUS : ImapClientConstants.MINUS).append(FLAGS_SP).append(argWriter.buildFlagString(flags))
                 .append(ImapClientConstants.CRLF);

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidCopyMessageCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidCopyMessageCommand.java
@@ -1,0 +1,34 @@
+package com.lafaspot.imapnio.async.request;
+
+import javax.annotation.Nonnull;
+
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * This class defines IMAP uid copy command from client.
+ */
+public class UidCopyMessageCommand extends AbstractMessageActionCommand {
+
+    /** Command name. */
+    private static final String COPY = "COPY";
+
+    /**
+     * Initializes a @{code UidCopyMessageCommand} with the message sequence syntax using UIDSet object.
+     *
+     * @param uidsets list of @{code UIDSet}
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidCopyMessageCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final String targetFolder) {
+        super(COPY, true, UIDSet.toString(uidsets), targetFolder);
+    }
+
+    /**
+     * Initializes a @{code UidCopyMessageCommand} with the message sequence syntax.
+     *
+     * @param uids the string representing UID based on RFC3501
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidCopyMessageCommand(@Nonnull final String uids, @Nonnull final String targetFolder) {
+        super(COPY, true, uids, targetFolder);
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidExpungeCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidExpungeCommand.java
@@ -1,0 +1,47 @@
+package com.lafaspot.imapnio.async.request;
+
+import javax.annotation.Nonnull;
+
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * This class defines IMAP UID EXPUNGE command from client.
+ */
+public class UidExpungeCommand extends ImapRequestAdapter {
+
+    /** Command name. */
+    private static final String UID_EXPUNGE = "UID EXPUNGE";
+
+    /** Message Id, aka UID. */
+    private String uids;
+
+    /**
+     * Initializes a @{code UidExpungeCommand} with the message sequence syntax.
+     *
+     * @param uidsets the set of UIDSet representing UID based on RFC3501
+     */
+    public UidExpungeCommand(@Nonnull final UIDSet[] uidsets) {
+        this(UIDSet.toString(uidsets));
+    }
+
+    /**
+     * Initializes a @{code UidExpungeCommand} with the message sequence syntax.
+     *
+     * @param uids the string representing UID string based on RFC3501
+     */
+    public UidExpungeCommand(@Nonnull final String uids) {
+        this.uids = uids;
+    }
+
+    @Override
+    public void cleanup() {
+        this.uids = null;
+    }
+
+    @Override
+    public String getCommandLine() {
+        final StringBuilder sb = new StringBuilder(UID_EXPUNGE).append(ImapClientConstants.SPACE).append(uids).append(ImapClientConstants.CRLF);
+
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidFetchCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidFetchCommand.java
@@ -1,0 +1,56 @@
+package com.lafaspot.imapnio.async.request;
+
+import javax.annotation.Nonnull;
+
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * This class defines IMAP UID fetch command request from client.
+ */
+public class UidFetchCommand extends ImapRequestAdapter {
+
+    /** UID FETCH and space. */
+    private static final String UID_FETCH_SPACE = "UID FETCH ";
+
+    /** Message UID. */
+    private String uids;
+
+    /** Fetch items. */
+    private String dataItems;
+
+    /**
+     * Initializes a @{code UidFetchCommand} with the message sequence syntax.
+     *
+     * @param uidsets the set of UID set
+     * @param what the data items or macro
+     */
+    public UidFetchCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final String what) {
+        this(UIDSet.toString(uidsets), what);
+    }
+
+    /**
+     * Initializes a @{code UidFetchCommand} with the message sequence syntax.
+     *
+     * @param uids the UID string following the RFC3501 syntax. For ex:3857529045,3857529047:3857529065
+     * @param what the data items or macro
+     */
+    public UidFetchCommand(@Nonnull final String uids, @Nonnull final String what) {
+        this.uids = uids;
+        this.dataItems = what;
+    }
+
+    @Override
+    public void cleanup() {
+        this.uids = null;
+        this.dataItems = null;
+    }
+
+    @Override
+    public String getCommandLine() {
+        final StringBuilder sb = new StringBuilder(dataItems.length() + ImapClientConstants.PAD_LEN).append(UID_FETCH_SPACE).append(uids)
+                .append(ImapClientConstants.SPACE).append(ImapClientConstants.L_PAREN).append(dataItems).append(ImapClientConstants.R_PAREN)
+                .append(ImapClientConstants.CRLF);
+
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidMoveMessageCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidMoveMessageCommand.java
@@ -1,0 +1,34 @@
+package com.lafaspot.imapnio.async.request;
+
+import javax.annotation.Nonnull;
+
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * This class defines imap move command request from client.
+ */
+public class UidMoveMessageCommand extends AbstractMessageActionCommand {
+
+    /** Command name. */
+    private static final String MOVE = "MOVE";
+
+    /**
+     * Initializes a @{code UidMoveMessageCommand} with the message sequence syntax.
+     *
+     * @param uidsets the list of UIDSet
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidMoveMessageCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final String targetFolder) {
+        super(MOVE, true, UIDSet.toString(uidsets), targetFolder);
+    }
+
+    /**
+     * Initializes a @{code UidMoveMessageCommand} with the message sequence syntax.
+     *
+     * @param uids the string representing UID based on RFC3501
+     * @param targetFolder the targetFolder to be stored
+     */
+    public UidMoveMessageCommand(@Nonnull final String uids, @Nonnull final String targetFolder) {
+        super(MOVE, true, uids, targetFolder);
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidSearchCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidSearchCommand.java
@@ -9,50 +9,50 @@ import javax.mail.search.SearchException;
 import javax.mail.search.SearchTerm;
 
 import com.lafaspot.imapnio.command.Argument;
-import com.sun.mail.imap.protocol.MessageSet;
 import com.sun.mail.imap.protocol.SearchSequence;
+import com.sun.mail.imap.protocol.UIDSet;
 
 /**
- * This class defines IMAP search command request from client.
+ * This class defines IMAP UID search command request from client.
  */
-public class SearchCommand extends ImapRequestAdapter {
+public class UidSearchCommand extends ImapRequestAdapter {
 
     /** Charset literal following by a space. */
     private static final String CHARSET = "CHARSET ";
 
-    /** Command name. */
-    private static final String SEARCH_SP = "SEARCH ";
+    /** UID SEARCH and space. */
+    private static final String UID_SEARCH_SPACE = "UID SEARCH ";
 
-    /** A collection of messages specified based on RFC3501 syntax. */
-    private String msgIds;
+    /** A collection of message UID specified based on RFC3501 syntax. */
+    private String uids;
 
     /** The search expression tree. */
     private SearchTerm term;
 
     /**
-     * Initializes a @{code SearchCommand} object with required parameters.
+     * Initializes a @{code UidSearchCommand} object with required parameters.
      *
-     * @param msgsets the set of message set
+     * @param uidsets the list of UID set
      * @param term the search expression tree
      */
-    public SearchCommand(@Nonnull final MessageSet[] msgsets, @Nonnull final SearchTerm term) {
-        this(MessageSet.toString(msgsets), term);
+    public UidSearchCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final SearchTerm term) {
+        this(UIDSet.toString(uidsets), term);
     }
 
     /**
-     * Initializes a @{code SearchCommand} with the msg string directly.
+     * Initializes a @{code UidSearchCommand} with the msg UID string directly.
      *
-     * @param msgIds the messages id string
+     * @param uids the messages UID string
      * @param term the search expression tree
      */
-    private SearchCommand(@Nonnull final String msgIds, @Nonnull final SearchTerm term) {
-        this.msgIds = msgIds;
+    private UidSearchCommand(@Nonnull final String uids, @Nonnull final SearchTerm term) {
+        this.uids = uids;
         this.term = term;
     }
 
     @Override
     public void cleanup() {
-        this.msgIds = null;
+        this.uids = null;
         this.term = null;
     }
 
@@ -65,11 +65,11 @@ public class SearchCommand extends ImapRequestAdapter {
         final SearchSequence searchSeq = new SearchSequence();
         final Argument args = new Argument();
         args.append(searchSeq.generateSequence(term, charset == null ? null : MimeUtility.javaCharset(charset)));
-        args.writeAtom(msgIds);
+        args.writeAtom(uids);
 
         final String searchStr = args.toString();
 
-        final StringBuilder sb = new StringBuilder(searchStr.length() + ImapClientConstants.PAD_LEN).append(SEARCH_SP);
+        final StringBuilder sb = new StringBuilder(searchStr.length() + ImapClientConstants.PAD_LEN).append(UID_SEARCH_SPACE);
 
         if (charset != null) {
             sb.append(CHARSET).append(charset).append(ImapClientConstants.SPACE);

--- a/core/src/main/java/com/lafaspot/imapnio/async/request/UidStoreFlagsCommand.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/request/UidStoreFlagsCommand.java
@@ -1,0 +1,69 @@
+package com.lafaspot.imapnio.async.request;
+
+import javax.annotation.Nonnull;
+import javax.mail.Flags;
+
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * This class defines IMAP UID store command request from client.
+ */
+public class UidStoreFlagsCommand extends ImapRequestAdapter {
+
+    /** UID STORE and space. */
+    private static final String UID_STORE_SPACE = "UID STORE ";
+
+    /** Literal for FLAGS. */
+    private static final String FLAGS_SP = "FLAGS ";
+
+    /** A collection of messages id specified based on RFC3501 syntax. */
+    private String uids;
+
+    /** Messages flags. */
+    private Flags flags;
+
+    /** Flag to indicate whether to add or remove existing. */
+    private final boolean isSet;
+
+    /**
+     * Initializes a @{code UidStoreFlagsCommand} with the UIDSet array.
+     *
+     * @param uidsets the set of uid set
+     * @param flags the flags to be stored
+     * @param set true if the specified flags are to be set, false to clear them
+     */
+    public UidStoreFlagsCommand(@Nonnull final UIDSet[] uidsets, @Nonnull final Flags flags, final boolean set) {
+        this(UIDSet.toString(uidsets), flags, set);
+    }
+
+    /**
+     * Initializes a @{code UidStoreFlagsCommand} with the uid string directly.
+     *
+     * @param uids the messages set
+     * @param flags the flags to be stored
+     * @param set true if the specified flags are to be set, false to clear them
+     */
+    public UidStoreFlagsCommand(@Nonnull final String uids, @Nonnull final Flags flags, final boolean set) {
+        this.uids = uids;
+        this.flags = flags;
+        this.isSet = set;
+    }
+
+    @Override
+    public void cleanup() {
+        this.uids = null;
+        this.flags = null;
+    }
+
+    @Override
+    public String getCommandLine() {
+        // Ex:STORE 2:4 +FLAGS (\Deleted)
+        final ImapArgumentFormatter argWriter = new ImapArgumentFormatter();
+        final StringBuilder sb = new StringBuilder(UID_STORE_SPACE).append(uids).append(ImapClientConstants.SPACE);
+
+        sb.append(isSet ? ImapClientConstants.PLUS : ImapClientConstants.MINUS).append(FLAGS_SP).append(argWriter.buildFlagString(flags))
+                .append(ImapClientConstants.CRLF);
+
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/com/lafaspot/imapnio/async/response/ImapAsyncResponse.java
+++ b/core/src/main/java/com/lafaspot/imapnio/async/response/ImapAsyncResponse.java
@@ -14,7 +14,7 @@ public class ImapAsyncResponse {
     /**
      * Initializes an @{code ImapAsyncResponse} object.
      *
-     * @param responses list of resonse lines
+     * @param responses list of response lines
      */
     public ImapAsyncResponse(final Collection<IMAPResponse> responses) {
         this.responses = responses;

--- a/core/src/test/java/com/lafaspot/imapnio/async/client/ImapAsyncClientTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/client/ImapAsyncClientTest.java
@@ -7,6 +7,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLException;
 
@@ -43,12 +44,9 @@ import io.netty.util.concurrent.GenericFutureListener;
 public class ImapAsyncClientTest {
 
     /** Timeout for connection. */
-    private static final String CONNECTION_TIMEOUT = "mail.imap.connectiontimeout";
-
-    /** Timeout for connection. */
     private static final String SERVER_URI_STR = "imaps://one.two.three.yahoo.com:993";
 
-    /** Timeout for connection. */
+    /** Server URI without SSL protocol. */
     private static final String NO_SSL_SERVER_URI_STR = "imap://one.two.three.yahoo.com:993";
 
     /**
@@ -76,17 +74,15 @@ public class ImapAsyncClientTest {
 
         final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
 
-
-        final Properties properties = new Properties();
-        properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-        properties.put("mail.imap.timeout", String.valueOf("60000"));
-        properties.put("mail.imap.inactivity", "3");
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
         final List<String> sniNames = null;
 
-        // test create sesssion
+        // test create session
         final InetSocketAddress localAddress = null;
         final URI serverUri = new URI(SERVER_URI_STR);
-        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
 
         // verify session creation
         Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
@@ -165,16 +161,15 @@ public class ImapAsyncClientTest {
 
         final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
 
-        final Properties properties = new Properties();
-        properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-        properties.put("mail.imap.timeout", String.valueOf("60000"));
-        properties.put("mail.imap.inactivity", "3");
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
         final List<String> sniNames = null;
 
         // test create sesssion
         final InetSocketAddress localAddress = null;
         final URI serverUri = new URI(NO_SSL_SERVER_URI_STR);
-        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
 
         // verify session creation
         Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
@@ -252,16 +247,15 @@ public class ImapAsyncClientTest {
 
         final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
 
-        final Properties properties = new Properties();
-        properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-        properties.put("mail.imap.timeout", String.valueOf("60000"));
-        properties.put("mail.imap.inactivity", "3");
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
         final List<String> sniNames = new ArrayList<String>();
 
         // test create sesssion
         final InetSocketAddress localAddress = null;
         final URI serverUri = new URI(SERVER_URI_STR);
-        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
 
         // verify session creation
         Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
@@ -336,16 +330,15 @@ public class ImapAsyncClientTest {
 
         final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
 
-        final Properties properties = new Properties();
-        properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-        properties.put("mail.imap.timeout", String.valueOf("60000"));
-        properties.put("mail.imap.inactivity", "3");
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);
         final List<String> sniNames = new ArrayList<String>();
         sniNames.add("imap.mail.yahoo.com");
         // test create sesssion
         final InetSocketAddress localAddress = new InetSocketAddress("10.10.10.10", 23112);
         final URI serverUri = new URI(SERVER_URI_STR);
-        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
 
         // verify session creation
         Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");
@@ -420,16 +413,15 @@ public class ImapAsyncClientTest {
 
         final ImapAsyncClient aclient = new ImapAsyncClient(bootstrap, group, logger);
 
-        final Properties properties = new Properties();
-        properties.put(CONNECTION_TIMEOUT, String.valueOf("5000"));
-        properties.put("mail.imap.timeout", String.valueOf("60000"));
-        properties.put("mail.imap.inactivity", "3");
+        final ImapAsyncSessionConfig config = new ImapAsyncSessionConfig();
+        config.setConnectionTimeoutMillis(5000);
+        config.setReadTimeoutMillis(6000);;
         final List<String> sniNames = null;
 
         // test create sesssion
         final InetSocketAddress localAddress = null;
         final URI serverUri = new URI(SERVER_URI_STR);
-        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, properties, localAddress, sniNames);
+        final ImapFuture<ImapAsyncSession> future = aclient.createSession(serverUri, config, localAddress, sniNames);
 
         // verify session creation
         Assert.assertNotNull(future, "Future for ImapAsyncSession should not be null.");

--- a/core/src/test/java/com/lafaspot/imapnio/async/data/IdResultTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/data/IdResultTest.java
@@ -1,0 +1,54 @@
+package com.lafaspot.imapnio.async.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for {@code IdResult}.
+ */
+public class IdResultTest {
+
+    /**
+     * Tests IdResult constructor and getters.
+     */
+    @Test
+    public void testIdResult() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("name", "Cyrus");
+        map.put("version", "1.5");
+        map.put("os", "sunos");
+        map.put("os-version", "5.5");
+        final String expectedVal = "mailto:cyrus-bugs+@andrew.cmu.edu";
+        map.put("support-url", expectedVal);
+
+        final IdResult idresult = new IdResult(map);
+
+        Assert.assertTrue(idresult.hasKey("name"), "Result mismatched.");
+        Assert.assertFalse(idresult.hasKey("Name"), "Result mismatched.");
+        Assert.assertTrue(idresult.hasKey("support-url"), "Result mismatched.");
+        Assert.assertEquals(idresult.getValue("support-url"), expectedVal, "Result mismatched.");
+
+    }
+
+    /**
+     * Tests IdResult constructor and getters.
+     */
+    @Test
+    public void testIdResultNullKey() {
+        final Map<String, String> map = new HashMap<>();
+        map.put("name", "Cyrus");
+        map.put("version", "1.5");
+        map.put("os", "sunos");
+        map.put("os-version", "5.5");
+        final String expectedVal = "mailto:cyrus-bugs+@andrew.cmu.edu";
+        map.put("support-url", expectedVal);
+
+        final IdResult idresult = new IdResult(map);
+        Assert.assertFalse(idresult.hasKey(null), "Result mismatched.");
+        final String nullKey = null;
+        Assert.assertNull(idresult.getValue(nullKey), "Result mismatched.");
+    }
+}

--- a/core/src/test/java/com/lafaspot/imapnio/async/exception/ImapAsyncClientExceptionTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/exception/ImapAsyncClientExceptionTest.java
@@ -29,6 +29,6 @@ public class ImapAsyncClientExceptionTest {
     public void testFailureType() {
         final ImapAsyncClientException.FailureType failureType = ImapAsyncClientException.FailureType.valueOf("CHANNEL_DISCONNECTED");
         Assert.assertEquals(failureType, ImapAsyncClientException.FailureType.CHANNEL_DISCONNECTED, "result mismatched.");
-        Assert.assertEquals(ImapAsyncClientException.FailureType.values().length, 14, "Number of enums mismatched.");
+        Assert.assertEquals(ImapAsyncClientException.FailureType.values().length, 15, "Number of enums mismatched.");
     }
 }

--- a/core/src/test/java/com/lafaspot/imapnio/async/internal/CompressCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/internal/CompressCommandTest.java
@@ -1,0 +1,66 @@
+package com.lafaspot.imapnio.async.internal;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.mail.search.SearchException;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
+import com.lafaspot.imapnio.async.internal.CompressCommand;
+import com.lafaspot.imapnio.async.request.ImapRequest;
+
+/**
+ * Unit test for {@code CompressCommand}.
+ */
+public class CompressCommandTest {
+
+    /** Fields to check for cleanup. */
+    private Set<Field> fieldsToCheck;
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
+        final Class<?> classUnderTest = CompressCommand.class;
+        fieldsToCheck = new HashSet<>();
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLine() throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final ImapRequest cmd = new CompressCommand();
+        Assert.assertEquals(cmd.getCommandLine(), "COMPRESS DEFLATE\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+}

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/CopyMessageCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/CopyMessageCommandTest.java
@@ -58,10 +58,9 @@ public class CopyMessageCommandTest {
     public void testMessageSequenceGetCommandLine()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
         final String folderName = "folderABC";
-        final boolean isUid = false;
         final int[] msgs = { 1, 2, 3 };
         final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-        final ImapRequest cmd = new CopyMessageCommand(isUid, msgsets, folderName);
+        final ImapRequest cmd = new CopyMessageCommand(msgsets, folderName);
         Assert.assertEquals(cmd.getCommandLine(), "COPY 1:3 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
@@ -84,9 +83,8 @@ public class CopyMessageCommandTest {
     public void testMessageUidGetCommandLine()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
         final String folderName = "folderABC";
-        final boolean isUid = true;
-        final ImapRequest cmd = new CopyMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID COPY 37850:37852 folderABC\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new CopyMessageCommand( 37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "COPY 37850:37852 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -105,9 +103,8 @@ public class CopyMessageCommandTest {
     @Test
     public void testGetCommandLineWithEscapeChar() throws IOException, ImapAsyncClientException, SearchException {
         final String folderName = "folder ABC";
-        final boolean isUid = true;
-        final ImapRequest cmd = new CopyMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID COPY 37850:37852 \"folder ABC\"\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new CopyMessageCommand( 37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "COPY 37850:37852 \"folder ABC\"\r\n", "Expected result mismatched.");
 
     }
 
@@ -121,8 +118,7 @@ public class CopyMessageCommandTest {
     @Test
     public void testGetCommandLineWithOtherCharSet() throws IOException, ImapAsyncClientException, SearchException {
         final String folderName = "测试";
-        final boolean isUid = true;
-        final ImapRequest cmd = new CopyMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID COPY 37850:37852 &bUuL1Q-\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new CopyMessageCommand(37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "COPY 37850:37852 &bUuL1Q-\r\n", "Expected result mismatched.");
     }
 }

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/FetchCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/FetchCommandTest.java
@@ -59,36 +59,11 @@ public class FetchCommandTest {
     @Test
     public void testGetCommandLineWithMessageSequence()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
-        final boolean isUid = false;
+
         final int[] msgs = { 1, 2, 3 };
         final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-        final ImapRequest cmd = new FetchCommand(isUid, msgsets, DATA_ITEMS);
+        final ImapRequest cmd = new FetchCommand(msgsets, DATA_ITEMS);
         Assert.assertEquals(cmd.getCommandLine(), "FETCH 1:3 (FLAGS BODY[HEADER.FIELDS (DATE FROM)])\r\n", "Expected result mismatched.");
-
-        cmd.cleanup();
-        // Verify if cleanup happened correctly.
-        for (final Field field : fieldsToCheck) {
-            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
-        }
-    }
-
-    /**
-     * Tests getCommandLine method using UID.
-     *
-     * @throws ImapAsyncClientException will not throw
-     * @throws SearchException will not throw
-     * @throws IOException will not throw
-     * @throws IllegalAccessException will not throw
-     * @throws IllegalArgumentException will not throw
-     */
-    @Test
-    public void testGetCommandLineWithUID()
-            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
-        final boolean isUid = true;
-        final int[] msgs = { 32321, 32322, 32323 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-        final ImapRequest cmd = new FetchCommand(isUid, msgsets, DATA_ITEMS);
-        Assert.assertEquals(cmd.getCommandLine(), "UID FETCH 32321:32323 (FLAGS BODY[HEADER.FIELDS (DATE FROM)])\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -109,10 +84,9 @@ public class FetchCommandTest {
     @Test
     public void testGetCommandLineWithStartEndConstructor()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
-        final boolean isUid = false;
-        final ImapRequest cmd = new FetchCommand(isUid, 1, 10000, DATA_ITEMS);
-        Assert.assertEquals(cmd.getCommandLine(), "FETCH 1:10000 (FLAGS BODY[HEADER.FIELDS (DATE FROM)])\r\n",
-                "Expected result mismatched.");
+
+        final ImapRequest cmd = new FetchCommand(1, 10000, DATA_ITEMS);
+        Assert.assertEquals(cmd.getCommandLine(), "FETCH 1:10000 (FLAGS BODY[HEADER.FIELDS (DATE FROM)])\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -126,8 +100,8 @@ public class FetchCommandTest {
      */
     @Test
     public void testGetStreamingResponsesQueue() {
-        final boolean isUid = false;
-        final ImapRequest cmd = new FetchCommand(isUid, 1, 10000, DATA_ITEMS);
+
+        final ImapRequest cmd = new FetchCommand(1, 10000, DATA_ITEMS);
         Assert.assertNull(cmd.getStreamingResponsesQueue(), "Expected result mismatched.");
     }
 
@@ -136,8 +110,8 @@ public class FetchCommandTest {
      */
     @Test
     public void testGetNextCommandLineAfterContinuation() {
-        final boolean isUid = false;
-        final ImapRequest cmd = new FetchCommand(isUid, 1, 10000, DATA_ITEMS);
+
+        final ImapRequest cmd = new FetchCommand(1, 10000, DATA_ITEMS);
         final IMAPResponse serverResponse = null; // null or not null does not matter
         ImapAsyncClientException ex = null;
         try {
@@ -155,8 +129,8 @@ public class FetchCommandTest {
      */
     @Test
     public void testGetTerminateCommandLine() {
-        final boolean isUid = false;
-        final ImapRequest cmd = new FetchCommand(isUid, 1, 10000, DATA_ITEMS);
+
+        final ImapRequest cmd = new FetchCommand(1, 10000, DATA_ITEMS);
         ImapAsyncClientException ex = null;
         try {
             cmd.getTerminateCommandLine();

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/MoveMessageCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/MoveMessageCommandTest.java
@@ -56,10 +56,9 @@ public class MoveMessageCommandTest {
     public void testMessageSequenceGetCommandLine()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
         final String folderName = "folderABC";
-        final boolean isUid = false;
         final int[] msgs = { 1, 2, 3 };
         final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-        final ImapRequest cmd = new MoveMessageCommand(isUid, msgsets, folderName);
+        final ImapRequest cmd = new MoveMessageCommand(msgsets, folderName);
         Assert.assertEquals(cmd.getCommandLine(), "MOVE 1:3 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
@@ -82,9 +81,8 @@ public class MoveMessageCommandTest {
     public void testMessageUidGetCommandLine()
             throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
         final String folderName = "folderABC";
-        final boolean isUid = true;
-        final ImapRequest cmd = new MoveMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new MoveMessageCommand(37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -103,9 +101,8 @@ public class MoveMessageCommandTest {
     @Test
     public void testGetCommandLineWithEscapeChar() throws ImapAsyncClientException, SearchException, IOException {
         final String folderName = "folder ABC";
-        final boolean isUid = true;
-        final ImapRequest cmd = new MoveMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 37850:37852 \"folder ABC\"\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new MoveMessageCommand(37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 \"folder ABC\"\r\n", "Expected result mismatched.");
 
     }
 
@@ -119,8 +116,7 @@ public class MoveMessageCommandTest {
     @Test
     public void testGetCommandLineWithOtherCharSet() throws ImapAsyncClientException, SearchException, IOException {
         final String folderName = "测试";
-        final boolean isUid = true;
-        final ImapRequest cmd = new MoveMessageCommand(isUid, 37850, 37852, folderName);
-        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 37850:37852 &bUuL1Q-\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new MoveMessageCommand(37850, 37852, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "MOVE 37850:37852 &bUuL1Q-\r\n", "Expected result mismatched.");
     }
 }

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/UidExpungeCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/UidExpungeCommandTest.java
@@ -1,0 +1,102 @@
+package com.lafaspot.imapnio.async.request;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.mail.search.SearchException;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
+import com.sun.mail.imap.protocol.UIDSet;
+
+/**
+ * Unit test for {@code UidExpungeCommand}.
+ */
+public class UidExpungeCommandTest {
+
+    /** Fields to check for cleanup. */
+    private Set<Field> fieldsToCheck;
+
+    /**
+     * Setup reflection.
+     */
+    @BeforeClass
+    public void setUp() {
+        // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
+        final Class<?> classUnderTest = UidExpungeCommand.class;
+        fieldsToCheck = new HashSet<>();
+        for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
+            for (final Field declaredField : c.getDeclaredFields()) {
+                if (!declaredField.getType().isPrimitive() && !Modifier.isStatic(declaredField.getModifiers())) {
+                    declaredField.setAccessible(true);
+                    fieldsToCheck.add(declaredField);
+                }
+            }
+        }
+    }
+
+    /**
+     * Tests getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithUIDSet()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        {
+            final UIDSet[] uidsets = { new UIDSet(43, 4294967295L) };
+            final ImapRequest cmd = new UidExpungeCommand(uidsets);
+            Assert.assertEquals(cmd.getCommandLine(), "UID EXPUNGE 43:4294967295\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+        {
+            long[] uids = { 4294967292L, 4294967291L, 4294967297L };
+            final UIDSet[] uidsets = UIDSet.createUIDSets(uids);
+            final ImapRequest cmd = new UidExpungeCommand(uidsets);
+            Assert.assertEquals(cmd.getCommandLine(), "UID EXPUNGE 4294967292,4294967291,4294967297\r\n", "Expected result mismatched.");
+
+            cmd.cleanup();
+            // Verify if cleanup happened correctly.
+            for (final Field field : fieldsToCheck) {
+                Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+            }
+        }
+    }
+
+    /**
+     * Tests getCommandLine method.
+     *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws IllegalArgumentException will not throw
+     */
+    @Test
+    public void testGetCommandLine() throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final ImapRequest cmd = new UidExpungeCommand("43:44,99");
+        Assert.assertEquals(cmd.getCommandLine(), "UID EXPUNGE 43:44,99\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+}

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/UidMoveMessageCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/UidMoveMessageCommandTest.java
@@ -6,24 +6,24 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
-import javax.mail.Flags;
-import javax.mail.search.FlagTerm;
 import javax.mail.search.SearchException;
-import javax.mail.search.SubjectTerm;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
+import com.lafaspot.imapnio.async.request.UidMoveMessageCommand;
 import com.lafaspot.imapnio.async.request.ImapRequest;
-import com.lafaspot.imapnio.async.request.SearchCommand;
 import com.sun.mail.imap.protocol.MessageSet;
+import com.sun.mail.imap.protocol.UIDSet;
 
 /**
- * Unit test for {@code SearchCommand}.
+ * Unit test for {@code UidMoveMessageCommand}.
  */
-public class SearchCommandTest {
+public class UidMoveMessageCommandTest {
+    /** Literal for MOVE. */
+    private static final String MOVE = "MOVE ";
 
     /** Fields to check for cleanup. */
     private Set<Field> fieldsToCheck;
@@ -34,7 +34,7 @@ public class SearchCommandTest {
     @BeforeClass
     public void setUp() {
         // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
-        final Class<?> classUnderTest = SearchCommand.class;
+        final Class<?> classUnderTest = UidMoveMessageCommand.class;
         fieldsToCheck = new HashSet<>();
         for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
             for (final Field declaredField : c.getDeclaredFields()) {
@@ -47,26 +47,22 @@ public class SearchCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using Message sequences.
+     * Tests getCommandLine method.
      *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
      * @throws IllegalArgumentException will not throw
-     * @throws ImapAsyncClientException will not throw
-     * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithMessageSequence()
-            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-        final Flags flags = new Flags();
-        flags.add(Flags.Flag.SEEN);
-        flags.add(Flags.Flag.DELETED);
-        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
-        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH DELETED SEEN 1:3\r\n", "Expected result mismatched.");
+    public void testMessageSequenceGetCommandLine()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String folderName = "folderABC";
+        final long[] uids = { 4294967293L, 4294967294L, 4294967295L };
+        final UIDSet[] msgsets = UIDSet.createUIDSets(uids);
+        final ImapRequest cmd = new UidMoveMessageCommand(msgsets, folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 4294967293:4294967295 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -76,23 +72,20 @@ public class SearchCommandTest {
     }
 
     /**
-     * Tests getCommandLine method using none ascii search strings.
+     * Tests getCommandLine method.
      *
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
      * @throws IOException will not throw
      * @throws IllegalAccessException will not throw
      * @throws IllegalArgumentException will not throw
-     * @throws ImapAsyncClientException will not throw
-     * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithNoneAscii()
-            throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
-
-        final SubjectTerm term = new SubjectTerm("ΩΩ"); // have none-ascii characters
-        final ImapRequest cmd = new SearchCommand(msgsets, term);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH CHARSET UTF-8 SUBJECT {4+}\r\nￎﾩￎﾩ 1:3\r\n", "Expected result mismatched.");
+    public void testMessageUidGetCommandLine()
+            throws IOException, ImapAsyncClientException, SearchException, IllegalArgumentException, IllegalAccessException {
+        final String folderName = "folderABC";
+        final ImapRequest cmd = new UidMoveMessageCommand("37850:37852", folderName);
+        Assert.assertEquals(cmd.getCommandLine(), "UID MOVE 37850:37852 folderABC\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/UidSearchCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/UidSearchCommandTest.java
@@ -17,13 +17,13 @@ import org.testng.annotations.Test;
 
 import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
 import com.lafaspot.imapnio.async.request.ImapRequest;
-import com.lafaspot.imapnio.async.request.SearchCommand;
-import com.sun.mail.imap.protocol.MessageSet;
+import com.lafaspot.imapnio.async.request.UidSearchCommand;
+import com.sun.mail.imap.protocol.UIDSet;
 
 /**
- * Unit test for {@code SearchCommand}.
+ * Unit test for {@code UidSearchCommand}.
  */
-public class SearchCommandTest {
+public class UidSearchCommandTest {
 
     /** Fields to check for cleanup. */
     private Set<Field> fieldsToCheck;
@@ -34,7 +34,7 @@ public class SearchCommandTest {
     @BeforeClass
     public void setUp() {
         // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
-        final Class<?> classUnderTest = SearchCommand.class;
+        final Class<?> classUnderTest = UidSearchCommand.class;
         fieldsToCheck = new HashSet<>();
         for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
             for (final Field declaredField : c.getDeclaredFields()) {
@@ -56,17 +56,17 @@ public class SearchCommandTest {
      * @throws SearchException will not throw
      */
     @Test
-    public void testGetCommandLineWithMessageSequence()
+    public void testGetCommandLineWithUIDSequence()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
 
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final long[] msgs = { 4294967292L, 4294967294L, 4294967295L };
+        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
-        final ImapRequest cmd = new SearchCommand(msgsets, messageFlagTerms);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH DELETED SEEN 1:3\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new UidSearchCommand(uidsets, messageFlagTerms);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH DELETED SEEN 4294967292,4294967294:4294967295\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -87,12 +87,38 @@ public class SearchCommandTest {
     @Test
     public void testGetCommandLineWithNoneAscii()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final long[] msgs = { 1L, 2L, 3L };
+        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
 
         final SubjectTerm term = new SubjectTerm("ΩΩ"); // have none-ascii characters
-        final ImapRequest cmd = new SearchCommand(msgsets, term);
-        Assert.assertEquals(cmd.getCommandLine(), "SEARCH CHARSET UTF-8 SUBJECT {4+}\r\nￎﾩￎﾩ 1:3\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new UidSearchCommand(uidsets, term);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH CHARSET UTF-8 SUBJECT {4+}\r\nￎﾩￎﾩ 1:3\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method using UID.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithUID() throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
+        final long[] msgs = { 4294967292L, 4294967294L, 4294967295L };
+        final UIDSet[] uidsets = UIDSet.createUIDSets(msgs);
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final FlagTerm messageFlagTerms = new FlagTerm(flags, true);
+        final ImapRequest cmd = new UidSearchCommand(uidsets, messageFlagTerms);
+        Assert.assertEquals(cmd.getCommandLine(), "UID SEARCH DELETED SEEN 4294967292,4294967294:4294967295\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.

--- a/core/src/test/java/com/lafaspot/imapnio/async/request/UidStoreFlagsCommandTest.java
+++ b/core/src/test/java/com/lafaspot/imapnio/async/request/UidStoreFlagsCommandTest.java
@@ -15,14 +15,14 @@ import org.testng.annotations.Test;
 
 import com.lafaspot.imapnio.async.exception.ImapAsyncClientException;
 import com.lafaspot.imapnio.async.request.ImapRequest;
-import com.lafaspot.imapnio.async.request.StoreFlagsCommand;
+import com.lafaspot.imapnio.async.request.UidStoreFlagsCommand;
 import com.sun.mail.imap.protocol.IMAPResponse;
-import com.sun.mail.imap.protocol.MessageSet;
+import com.sun.mail.imap.protocol.UIDSet;
 
 /**
- * Unit test for {@code StoreFlagsCommand}.
+ * Unit test for {@code UidStoreFlagsCommand}.
  */
-public class StoreFlagsCommandTest {
+public class UidStoreFlagsCommandTest {
 
     /** Fields to check for cleanup. */
     private Set<Field> fieldsToCheck;
@@ -33,7 +33,7 @@ public class StoreFlagsCommandTest {
     @BeforeClass
     public void setUp() {
         // Use reflection to get all declared non-primitive non-static fields (We do not care about inherited fields)
-        final Class<?> classUnderTest = StoreFlagsCommand.class;
+        final Class<?> classUnderTest = UidStoreFlagsCommand.class;
         fieldsToCheck = new HashSet<>();
         for (Class<?> c = classUnderTest; c != null; c = c.getSuperclass()) {
             for (final Field declaredField : c.getDeclaredFields()) {
@@ -58,14 +58,41 @@ public class StoreFlagsCommandTest {
     public void testGetCommandLineWithMessageSequence()
             throws IOException, IllegalArgumentException, IllegalAccessException, SearchException, ImapAsyncClientException {
 
-        final int[] msgs = { 1, 2, 3 };
-        final MessageSet[] msgsets = MessageSet.createMessageSets(msgs);
+        final long[] uids = { 4294967292L, 4294967294L, 4294967295L };
+        final UIDSet[] msgsets = UIDSet.createUIDSets(uids);
         final Flags flags = new Flags();
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(msgsets, flags, isSet);
-        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:3 +FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+        final ImapRequest cmd = new UidStoreFlagsCommand(msgsets, flags, isSet);
+        Assert.assertEquals(cmd.getCommandLine(), "UID STORE 4294967292,4294967294:4294967295 +FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
+
+        cmd.cleanup();
+        // Verify if cleanup happened correctly.
+        for (final Field field : fieldsToCheck) {
+            Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
+        }
+    }
+
+    /**
+     * Tests getCommandLine method using UID.
+     *
+     * @throws IOException will not throw
+     * @throws IllegalAccessException will not throw
+     * @throws ImapAsyncClientException will not throw
+     * @throws SearchException will not throw
+     */
+    @Test
+    public void testGetCommandLineWithUID() throws IOException, IllegalAccessException, SearchException, ImapAsyncClientException {
+  
+        final long[] uids = { 4294967293L, 4294967294L, 4294967295L };
+        final UIDSet[] msgsets = UIDSet.createUIDSets(uids);
+        final Flags flags = new Flags();
+        flags.add(Flags.Flag.SEEN);
+        flags.add(Flags.Flag.DELETED);
+        final boolean isSet = true;
+        final ImapRequest cmd = new UidStoreFlagsCommand(msgsets, flags, isSet);
+        Assert.assertEquals(cmd.getCommandLine(), "UID STORE 4294967293:4294967295 +FLAGS (\\Deleted \\Seen)\r\n", "Expected result mismatched.");
 
         cmd.cleanup();
         // Verify if cleanup happened correctly.
@@ -90,8 +117,8 @@ public class StoreFlagsCommandTest {
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final boolean isSet = false;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
-        Assert.assertEquals(cmd.getCommandLine(), "STORE 1:10000 -FLAGS (\\Deleted \\Seen)\r\n",
+        final ImapRequest cmd = new UidStoreFlagsCommand("1:10000", flags, isSet);
+        Assert.assertEquals(cmd.getCommandLine(), "UID STORE 1:10000 -FLAGS (\\Deleted \\Seen)\r\n",
                 "Expected result mismatched.");
 
         cmd.cleanup();
@@ -99,20 +126,6 @@ public class StoreFlagsCommandTest {
         for (final Field field : fieldsToCheck) {
             Assert.assertNull(field.get(cmd), "Cleanup should set " + field.getName() + " as null");
         }
-    }
-
-    /**
-     * Tests getStreamingResponsesQueue method.
-     */
-    @Test
-    public void testGetStreamingResponsesQueue() {
-
-        final Flags flags = new Flags();
-        flags.add(Flags.Flag.SEEN);
-        flags.add(Flags.Flag.DELETED);
-        final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
-        Assert.assertNull(cmd.getStreamingResponsesQueue(), "Expected result mismatched.");
     }
 
     /**
@@ -125,7 +138,7 @@ public class StoreFlagsCommandTest {
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
+        final ImapRequest cmd = new UidStoreFlagsCommand("1, 10000", flags, isSet);
         final IMAPResponse serverResponse = null; // null or not null does not matter
         ImapAsyncClientException ex = null;
         try {
@@ -148,7 +161,7 @@ public class StoreFlagsCommandTest {
         flags.add(Flags.Flag.SEEN);
         flags.add(Flags.Flag.DELETED);
         final boolean isSet = true;
-        final ImapRequest cmd = new StoreFlagsCommand(1, 10000, flags, isSet);
+        final ImapRequest cmd = new UidStoreFlagsCommand("1, 10000", flags, isSet);
         ImapAsyncClientException ex = null;
         try {
             cmd.getTerminateCommandLine();

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <excludedJNILibraries />
         <excludedWarJNILibraries />
         <jdk.version>1.8</jdk.version>
-        <maven-findbugs-plugin.version>3.0.1</maven-findbugs-plugin.version>
+        <maven-findbugs-plugin.version>3.0.5</maven-findbugs-plugin.version>
         <maven-surefire-plugin.version>2.17</maven-surefire-plugin.version>
         <maven-pmd-plugin.version>3.4</maven-pmd-plugin.version>
         <maven-checkstyle-plugin.version>2.13</maven-checkstyle-plugin.version>


### PR DESCRIPTION
1. Support Compression via startCompression() in AsyncSession, add handlers to deflate/inflate
2. Support Uid expunge command
3. Support parsing
 - response of Status command to Status object
 - response of ID command to IdResult
4. Use UIDSet or String to support 0 to 2^32 -1 values for UID values
5. Use Config class instead of Property class for ImapAsyncClient.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Major release (change is NOT backward compatible with prior release)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

